### PR TITLE
Add Rust version 1.56.0 to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Optimized handling of `[u8; N]` for Serde"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nitrokey/serde-byte-array"
 edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 serde = { version = "1.0.152", default-features = false }
@@ -16,4 +17,3 @@ bincode = "1.3.3"
 
 serde = { version = "1.0.152", default-features = false, features = ["derive"] }
 serde_test = "1.0.152"
-


### PR DESCRIPTION
Rust 1.56.0 is the first release that supports the 2021 edition.  Adding it to Cargo.toml silences a clippy warning regarding inlined format arguments.